### PR TITLE
feat: allow module imports

### DIFF
--- a/lib/common/RLSPostgresQueryRunner.ts
+++ b/lib/common/RLSPostgresQueryRunner.ts
@@ -26,8 +26,9 @@ export class RLSPostgresQueryRunner extends PostgresQueryRunner {
   }
 
   async query(queryString: string, params?: any[]): Promise<any> {
-    await super.query(`set "rls.tenant_id" = ${this.tenantId}`);
-    await super.query(`set "rls.actor_id" = ${this.actorId}`);
+    await super.query(
+      `set "rls.tenant_id" = '${this.tenantId}'; set "rls.actor_id" = '${this.actorId}';`,
+    );
 
     const result = await super.query(queryString, params);
     await super.query(`reset rls.actor_id; reset rls.tenant_id;`);

--- a/lib/rls.module.ts
+++ b/lib/rls.module.ts
@@ -1,6 +1,7 @@
 import {
   Abstract,
   DynamicModule,
+  ForwardReference,
   Global,
   Module,
   Provider,
@@ -44,6 +45,12 @@ export class RLSModule {
   }
 
   static forRoot(
+    importModules: (
+      | DynamicModule
+      | Type<any>
+      | Promise<DynamicModule>
+      | ForwardReference<any>
+    )[],
     // eslint-disable-next-line @typescript-eslint/ban-types
     injectServices: (string | symbol | Function | Type<any> | Abstract<any>)[],
     extractTenant: (request, ...args) => TenancyModelOptions,
@@ -63,6 +70,7 @@ export class RLSModule {
 
     return {
       module: RLSModule,
+      imports: importModules,
       providers: [rlsProvider],
       exports: [TENANT_CONNECTION],
     };

--- a/test/common/EntityManager.spec.ts
+++ b/test/common/EntityManager.spec.ts
@@ -198,7 +198,7 @@ describe('EntityManager', function () {
       await Promise.all(promises).then(async results => {
         let i = 0;
         // should have 4 queries per call * 20 queries
-        await expect(queryPrototypeSpy).to.have.callCount(80);
+        await expect(queryPrototypeSpy).to.have.callCount(60);
 
         // should have had 20 calls in total. One per query
         await expect(connectedQueryRunnersStub).to.have.callCount(20);

--- a/test/common/QueryBuilder.spec.ts
+++ b/test/common/QueryBuilder.spec.ts
@@ -217,7 +217,7 @@ describe('QueryBuilder', function () {
       await Promise.all(promises).then(async results => {
         let i = 0;
         // should have 4 queries per call * 20 queries
-        await expect(queryPrototypeSpy).to.have.callCount(80);
+        await expect(queryPrototypeSpy).to.have.callCount(60);
 
         // should have had 20 calls in total. One per query
         await expect(connectedQueryRunnersStub).to.have.callCount(20);

--- a/test/common/RLSPostgresQueryRunner.spec.ts
+++ b/test/common/RLSPostgresQueryRunner.spec.ts
@@ -406,11 +406,11 @@ describe('RLSPostgresQueryRunner', () => {
         await localQueryRunner.release();
       });
 
-      it('should have 8 calls in total', async () => {
+      it('should have 6 calls in total', async () => {
         await queryRunner.query(fooQueryString);
         await localQueryRunner.query(barQueryString);
 
-        expect(queryPrototypeStub).to.have.callCount(8);
+        expect(queryPrototypeStub).to.have.callCount(6);
       });
 
       it('should return the right categories', async () => {
@@ -467,9 +467,9 @@ describe('RLSPostgresQueryRunner', () => {
           fooTenant,
         );
 
-        // The stub should have 8 calls in total
-        // 4 for each query
-        expect(queryPrototypeStub).to.have.callCount(8);
+        // The stub should have 6 calls in total
+        // 3 for each query
+        expect(queryPrototypeStub).to.have.callCount(6);
       });
 
       it('should not have race conditions on multiple runners', async () => {

--- a/test/common/Repository.spec.ts
+++ b/test/common/Repository.spec.ts
@@ -213,7 +213,7 @@ describe('Repository', function () {
       await Promise.all(promises).then(async results => {
         let i = 0;
         // should have 4 queries per call * 20 queries
-        await expect(queryPrototypeSpy).to.have.callCount(80);
+        await expect(queryPrototypeSpy).to.have.callCount(60);
 
         // should have had 20 calls in total. One per query
         await expect(connectedQueryRunnersStub).to.have.callCount(20);

--- a/test/nestjs/src/app.module.ts
+++ b/test/nestjs/src/app.module.ts
@@ -19,7 +19,7 @@ const configs = getTypeOrmConfig();
       entities: [Post, Category],
       logging: false,
     } as ConnectionOptions),
-    RLSModule.forRoot([], (req: Request) => {
+    RLSModule.forRoot([], [], (req: Request) => {
       const tenantId = req.headers['tenant_id'] as string;
       const actorId = req.headers['actor_id'] as string;
 

--- a/test/util/helpers.ts
+++ b/test/util/helpers.ts
@@ -97,41 +97,33 @@ export function runQueryTests(
     sinon.restore();
   });
 
-  it('gets called 4 times on normal execution', async () => {
+  it('gets called 3 times on normal execution', async () => {
     await queryRunner.query('');
-    expect(queryPrototypeSpy).to.have.callCount(4);
+    expect(queryPrototypeSpy).to.have.callCount(3);
     expect(querySpy).to.have.callCount(1);
   });
 
   it('gets called with right query and no params', async () => {
     await queryRunner.query(`select 'foo'`);
 
-    expect(queryPrototypeSpy.thirdCall).to.have.been.calledWith(`select 'foo'`);
+    expect(queryPrototypeSpy.secondCall).to.have.been.calledWith(
+      `select 'foo'`,
+    );
   });
 
   it('gets called with right query and params', async () => {
     await queryRunner.query(`select $1`, ['foo']);
 
-    expect(queryPrototypeSpy.thirdCall).to.have.been.calledWith('select $1', [
+    expect(queryPrototypeSpy.secondCall).to.have.been.calledWith('select $1', [
       'foo',
     ]);
   });
 
-  it('gets called with right tenantId', async () => {
+  it('gets called with right tenantId and actor_id', async () => {
     await queryRunner.query(`select 'foo'`);
 
     expect(queryPrototypeSpy.firstCall).to.have.been.calledWith(
-      // `select set_config('rls.tenant_id', '${tenantModelOptions.tenantId}', false)`,
-      `set "rls.tenant_id" = ${tenantModelOptions.tenantId}`,
-    );
-  });
-
-  it('gets called with right actorId', async () => {
-    await queryRunner.query(`select 'foo'`);
-
-    expect(queryPrototypeSpy.secondCall).to.have.been.calledWith(
-      // `select set_config('rls.actor_id', '${tenantModelOptions.actorId}', false)`,
-      `set "rls.actor_id" = ${tenantModelOptions.actorId}`,
+      `set "rls.tenant_id" = '${tenantModelOptions.tenantId}'; set "rls.actor_id" = '${tenantModelOptions.actorId}';`,
     );
   });
 


### PR DESCRIPTION
Allow Nestjs `forRoot` to import modules and services.
Refactor RLSQueryRunner to use 3 queries instead of 4.