### PR TITLE
fix(manager): use the right manager for repository

### DIFF
--- a/lib/common/RLSConnection.ts
+++ b/lib/common/RLSConnection.ts
@@ -61,7 +61,10 @@ export class RLSConnection extends Connection {
   }
 
   createQueryRunner(): RLSPostgresQueryRunner {
-    return super.createQueryRunner() as RLSPostgresQueryRunner;
+    const qr = super.createQueryRunner() as RLSPostgresQueryRunner;
+    Object.assign(qr, { manager: this.manager });
+
+    return qr;
   }
 
   close(): Promise<void> {

--- a/test/common/Repository.spec.ts
+++ b/test/common/Repository.spec.ts
@@ -1,6 +1,13 @@
 import { expect } from 'chai';
 import sinon = require('sinon');
-import { Connection, ConnectionOptions, createConnection } from 'typeorm';
+import {
+  Connection,
+  ConnectionOptions,
+  createConnection,
+  EntityManager,
+  getConnection,
+  getRepository,
+} from 'typeorm';
 import { PostgresDriver } from 'typeorm/driver/postgres/PostgresDriver';
 import { PostgresQueryRunner } from 'typeorm/driver/postgres/PostgresQueryRunner';
 import { RLSConnection } from '../../lib/common';
@@ -166,6 +173,19 @@ describe('Repository', function () {
       await expectTenantData(expect(bar), categories, 1, barTenant);
       await expect(cat).to.have.lengthOf(2).and.to.deep.equal(categories);
     });
+  });
+
+  it('should throw database error on first query and fulfill the second query', async () => {
+    const fooCategoryRepository = fooConnection.getRepository(Category);
+
+    await expect(
+      fooCategoryRepository.save({
+        name: 'Test',
+        numberValue: '@@@@' as any,
+      }),
+    ).to.be.rejected;
+
+    await expect(fooCategoryRepository.find()).to.be.fulfilled;
   });
 
   describe('queued queries', () => {

--- a/test/util/entity/Category.ts
+++ b/test/util/entity/Category.ts
@@ -11,11 +11,15 @@ export class Category extends BaseEntity {
   @Column()
   name: string;
 
+  @Column({ type: 'boolean', nullable: true })
+  numberValue: boolean;
+
   toJson() {
     return {
       id: this.id,
       tenantId: this.tenantId,
       name: this.name,
+      numberValue: this.numberValue,
     };
   }
 }


### PR DESCRIPTION
When creating a new repository we now override the manager with the RLS
wrapped one from the connection.