### PR TITLE
fix: rls settings on connection in pg pool

### DIFF
--- a/lib/common/RLSPostgresQueryRunner.ts
+++ b/lib/common/RLSPostgresQueryRunner.ts
@@ -38,12 +38,20 @@ export class RLSPostgresQueryRunner extends PostgresQueryRunner {
       );
     }
 
-    const result = await super.query(queryString, params, useStructuredResult);
+    let result: Promise<any>;
+    let error: Error;
+    try {
+      result = await super.query(queryString, params, useStructuredResult);
+    } catch (err) {
+      error = err;
+    }
 
     if (!this.isTransactionCommand) {
       await super.query(`reset rls.actor_id; reset rls.tenant_id;`);
     }
-    return result;
+
+    if (error) throw error;
+    else return result;
   }
 
   async startTransaction(isolationLevel?: IsolationLevel): Promise<void> {

--- a/test/common/RLSPostgresQueryRunner.spec.ts
+++ b/test/common/RLSPostgresQueryRunner.spec.ts
@@ -1,4 +1,4 @@
-import { AssertionError, expect } from 'chai';
+import { expect } from 'chai';
 import * as sinon from 'sinon';
 import {
   Connection,
@@ -13,6 +13,8 @@ import {
   RLSPostgresQueryRunner,
 } from '../../lib/common';
 import { TenancyModelOptions } from '../interfaces';
+import { Category } from '../util/entity/Category';
+import { Post } from '../util/entity/Post';
 import {
   createData,
   createRunners,
@@ -32,8 +34,6 @@ import {
   reloadTestingDatabases,
   setupSingleTestingConnection,
 } from '../util/test-utils';
-import { Category } from '../util/entity/Category';
-import { Post } from '../util/entity/Post';
 const configs = getTypeOrmConfig();
 
 describe('RLSPostgresQueryRunner', () => {

--- a/test/util/test-utils.ts
+++ b/test/util/test-utils.ts
@@ -171,6 +171,7 @@ export function setupSingleTestingConnection(
       namingStrategy: options.namingStrategy
         ? options.namingStrategy
         : undefined,
+      logging: options.logging ?? false,
     },
     typeormConfig ? [typeormConfig] : undefined,
   );


### PR DESCRIPTION
# Description

> Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- Fix a bug where the rls settings would remain in the connection for the pool. 
 
This is an edge case where it can only affect queries outside of the RLS environment. For example if a query fails, the connection is returned to the pool. If a non-rls datasource is used (for example the original typeorm datasource) and it picks the pg pool connection, then it would actually be scoped with the rls parameters. However this does not affect the queries that happen through RLS scoped connections (RLSConnection/RLSQueryRunner) since those queries would overwrite the rls settings.

# Type of change

> Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change which does not add functionality)

# Checklist:

- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
