### PR TITLE
fix: rls settings on connection in pg pool

### DIFF
--- a/lib/common/RLSPostgresQueryRunner.ts
+++ b/lib/common/RLSPostgresQueryRunner.ts
@@ -38,12 +38,20 @@ export class RLSPostgresQueryRunner extends PostgresQueryRunner {
       );
     }
 
-    const result = await super.query(queryString, params, useStructuredResult);
+    let result: Promise<any>;
+    let error: Error;
+    try {
+      result = await super.query(queryString, params, useStructuredResult);
+    } catch (err) {
+      error = err;
+    }
 
     if (!this.isTransactionCommand) {
       await super.query(`reset rls.actor_id; reset rls.tenant_id;`);
     }
-    return result;
+
+    if (error) throw error;
+    else return result;
   }
 
   async startTransaction(isolationLevel?: IsolationLevel): Promise<void> {

--- a/test/common/RLSPostgresQueryRunner.spec.ts
+++ b/test/common/RLSPostgresQueryRunner.spec.ts
@@ -521,4 +521,93 @@ describe('RLSPostgresQueryRunner', () => {
       });
     });
   });
+
+  describe('connection pool with size 1', () => {
+    const tenantDbUser = 'tenant_aware_user';
+    let singleConnection: Connection;
+    let fooRlsConnection: RLSConnection;
+    let singleQueryRunner: RLSPostgresQueryRunner;
+    let localDriver: RLSPostgresDriver;
+
+    before(async () => {
+      const tenantConnectionOptions = await setupSingleTestingConnection(
+        'postgres',
+        {
+          entities: [Post, Category],
+          logging: false,
+        },
+        {
+          ...configs[0],
+          name: 'tenantConnection',
+          extra: {
+            size: 1,
+          },
+          logging: false,
+        } as ConnectionOptions,
+      );
+
+      singleConnection = await createConnection(tenantConnectionOptions);
+      fooRlsConnection = new RLSConnection(singleConnection, fooTenant);
+      localDriver = fooRlsConnection.driver;
+    });
+
+    beforeEach(async () => {
+      singleQueryRunner = new RLSPostgresQueryRunner(
+        localDriver,
+        'master',
+        fooTenant,
+      );
+
+      await createTeantUser(migrationConnection, tenantDbUser);
+      await setupMultiTenant(migrationConnection, tenantDbUser);
+      await setQueryRunnerRole(singleQueryRunner, tenantDbUser);
+      await createData(fooTenant, barTenant, migrationConnection);
+    });
+
+    afterEach(async () => {
+      await resetMultiTenant(migrationConnection, tenantDbUser);
+      await singleQueryRunner.release();
+    });
+
+    after(async () => await closeTestingConnections([singleConnection]));
+
+    it('should not persist the settings in connection from the pool', async () => {
+      // Force throwing an error in the query
+      await expect(singleQueryRunner.query('select * from non_existing_table'))
+        .to.eventually.be.rejectedWith(
+          `relation "non_existing_table" does not exist`,
+        )
+        .and.be.instanceOf(QueryFailedError);
+      await singleQueryRunner.release();
+
+      // Since we released the queryrunner back in the pool, when we create a new one
+      // we in fact receive the one used above from pg pool
+      const queryRunner2 = singleConnection.createQueryRunner();
+
+      /**
+       * Since this query is not RLS bound, this will return the set tenant
+       * If the reset executes (therefore not leaking),
+       * the tenantId and actorId properties should be empty
+       */
+      const [{ tenantId }] = await queryRunner2.query(
+        `select current_setting('rls.tenant_id') as "tenantId"`,
+      );
+      expect(tenantId).to.be.empty;
+
+      const [{ actorId }] = await queryRunner2.query(
+        `select current_setting('rls.actor_id') as "actorId"`,
+      );
+      expect(actorId).to.be.empty;
+
+      /**
+       * Executing a query that is RLS bound should fail because
+       * tenant_id and actor_id needed by the RLS policy should not
+       * be set. They are only set if the connection is not reset correctly
+       */
+      await expect(
+        queryRunner2.query('select * from category'),
+      ).to.eventually.be.rejectedWith(/invalid input syntax/);
+      await queryRunner2.release();
+    });
+  });
 });

--- a/test/util/test-utils.ts
+++ b/test/util/test-utils.ts
@@ -172,6 +172,7 @@ export function setupSingleTestingConnection(
       namingStrategy: options.namingStrategy
         ? options.namingStrategy
         : undefined,
+      logging: options.logging ?? false,
     },
     typeormConfig ? [typeormConfig] : undefined,
   );


### PR DESCRIPTION
# Description

> Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- Fix a bug where the rls settings would remain in the connection for the pool.

This is an edge case where it can only affect queries outside of the RLS environment. For example if a query fails, the connection is returned to the pool. If a non-rls datasource is used (for example the original typeorm datasource) and it picks the pg pool connection, then it would actually be scoped with the rls parameters. However this does not affect the queries that happen through RLS scoped connections (RLSConnection/RLSQueryRunner) since those queries would overwrite the rls settings.

This is a backport from master

# Type of change

> Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change which does not add functionality)

# Checklist:

- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
