### PR TITLE
Fixes issue #213

### DIFF
--- a/lib/common/RLSPostgresQueryRunner.ts
+++ b/lib/common/RLSPostgresQueryRunner.ts
@@ -46,7 +46,7 @@ export class RLSPostgresQueryRunner extends PostgresQueryRunner {
       error = err;
     }
 
-    if (!this.isTransactionCommand) {
+    if (!this.isTransactionCommand && !(this.isTransactionActive && error)) {
       await super.query(`reset rls.actor_id; reset rls.tenant_id;`);
     }
 

--- a/test/util/helpers.ts
+++ b/test/util/helpers.ts
@@ -135,6 +135,18 @@ export function runQueryTests(
     );
   });
 
+  it('throws correct error in a failed transactional query', async () => {
+    await queryRunner.startTransaction();
+    await expect(queryRunner.query(`'foo'`)).to.be.rejectedWith(
+      `syntax error at or near "'foo'"`,
+    );
+    await queryRunner.rollbackTransaction();
+
+    expect(queryPrototypeSpy).not.to.have.been.calledWith(
+      `reset rls.actor_id; reset rls.tenant_id;`,
+    );
+  });
+
   it('does not add ghost query runners to the driver', () => {
     expect(queryRunner.driver.connectedQueryRunners).to.have.lengthOf(0);
   });


### PR DESCRIPTION
# Description

Added a check to NOT run the `reset rls.actor_id; reset rls.tenant_id;` query if a transaction is active and there was an error (Postgres -- by default -- does not allow additional queries to be executed in a transaction after an error).

# Type of change

> Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change which does not add functionality)

# Checklist:

- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
