### PR TITLE
feat: Add support for typeorm  streams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "nyc": "^15.1.0",
         "opn": "^6.0.0",
         "pg": "^8.7.3",
+        "pg-query-stream": "^4.5.3",
         "prettier": "^2.7.1",
         "rxjs": "^7.5.6",
         "semantic-release": "^19.0.3",
@@ -9736,6 +9737,15 @@
       "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==",
       "dev": true
     },
+    "node_modules/pg-cursor": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.10.3.tgz",
+      "integrity": "sha512-rDyBVoqPVnx/PTmnwQAYgusSeAKlTL++gmpf5klVK+mYMFEqsOc6VHHZnPKc/4lOvr4r6fiMuoxSFuBF1dx4FQ==",
+      "dev": true,
+      "peerDependencies": {
+        "pg": "^8"
+      }
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -9759,6 +9769,18 @@
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
       "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==",
       "dev": true
+    },
+    "node_modules/pg-query-stream": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.5.3.tgz",
+      "integrity": "sha512-ufa94r/lHJdjAm3+zPZEO0gXAmCb4tZPaOt7O76mjcxdL/HxwTuryy76km+u0odBBgtfdKFYq/9XGfiYeQF0yA==",
+      "dev": true,
+      "dependencies": {
+        "pg-cursor": "^2.10.3"
+      },
+      "peerDependencies": {
+        "pg": "^8"
+      }
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
@@ -19607,6 +19629,13 @@
       "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==",
       "dev": true
     },
+    "pg-cursor": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.10.3.tgz",
+      "integrity": "sha512-rDyBVoqPVnx/PTmnwQAYgusSeAKlTL++gmpf5klVK+mYMFEqsOc6VHHZnPKc/4lOvr4r6fiMuoxSFuBF1dx4FQ==",
+      "dev": true,
+      "requires": {}
+    },
     "pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -19625,6 +19654,15 @@
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
       "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==",
       "dev": true
+    },
+    "pg-query-stream": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.5.3.tgz",
+      "integrity": "sha512-ufa94r/lHJdjAm3+zPZEO0gXAmCb4tZPaOt7O76mjcxdL/HxwTuryy76km+u0odBBgtfdKFYq/9XGfiYeQF0yA==",
+      "dev": true,
+      "requires": {
+        "pg-cursor": "^2.10.3"
+      }
     },
     "pg-types": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "nyc": "^15.1.0",
     "opn": "^6.0.0",
     "pg": "^8.7.3",
+    "pg-query-stream": "^4.5.3",
     "prettier": "^2.7.1",
     "rxjs": "^7.5.6",
     "semantic-release": "^19.0.3",

--- a/test/nestjs/e2e/rls.module.spec.ts
+++ b/test/nestjs/e2e/rls.module.spec.ts
@@ -93,6 +93,14 @@ describe('RLS Module', () => {
       });
   });
 
+  it('GET /posts using stream for foo tenant', async () => {
+    return getAuthRequest(app, 'get', '/posts?useStream=true', fooTenant)
+      .expect(200)
+      .expect(res => {
+        expectTenantData(expect(res.body), posts, 1, fooTenant, true);
+      });
+  });
+
   it('GET /categories for bar tenant', () => {
     return getAuthRequest(app, 'get', '/categories', barTenant)
       .expect(200)

--- a/test/nestjs/src/app.controller.ts
+++ b/test/nestjs/src/app.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { AppService } from './app.service';
 
 @Controller()
@@ -11,8 +11,8 @@ export class AppController {
   }
 
   @Get('/posts')
-  getPosts(): Promise<any> {
-    return this.appService.getPosts();
+  getPosts(@Query('useStream') useStream?: boolean): Promise<any> {
+    return this.appService.getPosts(useStream);
   }
 
   @Get('/categories')

--- a/test/nestjs/src/app.service.ts
+++ b/test/nestjs/src/app.service.ts
@@ -28,7 +28,25 @@ export class AppService {
     return this.categoryRepo.find();
   }
 
-  async getPosts() {
+  async getPosts(useStream?: boolean) {
+    if (useStream) {
+      const result = [];
+      const stream = await this.postRepo.createQueryBuilder('post').stream();
+      await new Promise<void>((resolve, reject) => {
+        stream.on('data', (data: any) => {
+          //Query builder does not format the output the same way that the repository does
+          result.push({
+            id: data.post_id,
+            tenantId: data.post_tenantId,
+            title: data.post_title,
+            userId: data.post_userId,
+          });
+        });
+        stream.on('error', reject);
+        stream.on('end', resolve);
+      });
+      return result;
+    }
     return this.postRepo.read();
   }
 


### PR DESCRIPTION
# Description

Overriding the `stream` method from the parent [PostgresQueryRunner](https://github.com/typeorm/typeorm/blob/83567f533482d0170c35e2f99e627962b8f99a08/src/driver/postgres/PostgresQueryRunner.ts#L340) to set/reset the rls variables. Without this `unrecognized configuration parameter "rls.tenant_id"` is thrown when trying to use streams

Adding dev dependency on `pg-query-stream`, which typeorm will try to load when using streams. 
https://github.com/typeorm/typeorm/blob/83567f533482d0170c35e2f99e627962b8f99a08/src/driver/postgres/PostgresDriver.ts#L1431

# Type of change

> Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change which does not add functionality)

# Checklist:

- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
