### PR TITLE
 fix: multiple queries in transaction for the same connection in the pool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "pg-query-stream": "^4.8.1",
         "prettier": "^3.5.3",
         "rxjs": "^7.8.2",
+        "seedrandom": "^3.0.5",
         "semantic-release": "^24.2.3",
         "sinon": "^20.0.0",
         "sinon-chai": "^4.0.0",
@@ -13592,6 +13593,13 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "pg-query-stream": "^4.8.1",
     "prettier": "^3.5.3",
     "rxjs": "^7.8.2",
+    "seedrandom": "^3.0.5",
     "semantic-release": "^24.2.3",
     "sinon": "^20.0.0",
     "sinon-chai": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:stelescuraul/rls.git"
+    "url": "git+ssh://git@github.com/stelescuraul/rls.git"
   },
   "author": "Raul Stelescu",
   "license": "ISC",

--- a/test/common/RLSPostgresQueryRunner.spec.ts
+++ b/test/common/RLSPostgresQueryRunner.spec.ts
@@ -55,13 +55,13 @@ describe('RLSPostgresQueryRunner', () => {
   };
 
   before(async () => {
-    const connectionOptions = await setupSingleTestingConnection('postgres', {
+    const connectionOptions = setupSingleTestingConnection('postgres', {
       entities: [Post, Category],
       dropSchema: true,
       schemaCreate: true,
     });
 
-    const migrationConnectionOptions = await setupSingleTestingConnection(
+    const migrationConnectionOptions = setupSingleTestingConnection(
       'postgres',
       {
         entities: [Post, Category],
@@ -570,7 +570,9 @@ describe('RLSPostgresQueryRunner', () => {
           .stub(PostgresQueryRunner.prototype, 'query')
           .callThrough();
 
-        clock = sinon.useFakeTimers();
+        clock = sinon.useFakeTimers({
+          toFake: ['setTimeout'],
+        });
       });
 
       afterEach(async () => {
@@ -702,7 +704,7 @@ describe('RLSPostgresQueryRunner', () => {
     let localDriver: RLSPostgresDriver;
 
     before(async () => {
-      const tenantConnectionOptions = await setupSingleTestingConnection(
+      const tenantConnectionOptions = setupSingleTestingConnection(
         'postgres',
         {
           entities: [Post, Category],
@@ -712,7 +714,7 @@ describe('RLSPostgresQueryRunner', () => {
           ...configs[0],
           name: 'tenantConnection',
           extra: {
-            size: 1,
+            poolSize: 1,
           },
           logging: false,
         } as ConnectionOptions,

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     command: npm run test:mocha
     volumes:
       - /usr/src/app/node_modules
+      - ../:/usr/src/app
     depends_on:
       - postgres
     environment: 


### PR DESCRIPTION
# Description

Fix an issue where multiple queries in the same transaction would override the rls session settings.
Fixes https://github.com/stelescuraul/rls/issues/224

# Type of change

> Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change which does not add functionality)

# Checklist

- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
